### PR TITLE
feat :enables loading all token types at once

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -206,6 +206,8 @@ const Settings: FC<SettingsProps> = ({ location }) => {
               setColors={handleUpdateData(setColors)}
               setWithDarkMode={handleUpdateData(setWithDarkMode)}
               setAllowGroups={handleUpdateData(setAllowedGroup)}
+              setDimensions={handleUpdateData(setDimensions)}
+              setBorders={handleUpdateData(setBorders)}
             />
           );
         case 'size-dimension':
@@ -215,6 +217,8 @@ const Settings: FC<SettingsProps> = ({ location }) => {
               dimensions={dimensions}
               setDimensions={handleUpdateData(setDimensions)}
               setAllowGroups={handleUpdateData(setAllowedGroup)}
+              setColors={handleUpdateData(setColors)}
+              setBorders={handleUpdateData(setBorders)}
             />
           );
         case 'font':
@@ -234,6 +238,8 @@ const Settings: FC<SettingsProps> = ({ location }) => {
               setBorders={handleUpdateData(setBorders)}
               colors={colors}
               dimensions={dimensions}
+              setColors={handleUpdateData(setColors)}
+              setDimensions={handleUpdateData(setDimensions)}
             />
           );
         case 'webhooks':

--- a/src/components/Settings/Tabs/Border.tsx
+++ b/src/components/Settings/Tabs/Border.tsx
@@ -188,9 +188,19 @@ type BorderProps = {
   setBorders: Dispatch<SetStateAction<NonNullable<Type.KVStorage['borders']>>>;
   colors: NonNullable<Type.KVStorage['colors']>;
   dimensions: NonNullable<Type.KVStorage['dimensions']>;
+  setColors: Dispatch<SetStateAction<NonNullable<Type.KVStorage['colors']>>>;
+  setDimensions: Dispatch<SetStateAction<NonNullable<Type.KVStorage['dimensions']>>>;
 };
 
-const Border: FC<BorderProps> = ({ withDarkMode, borders, setBorders, colors, dimensions }) => {
+const Border: FC<BorderProps> = ({
+  withDarkMode,
+  borders,
+  setBorders,
+  setColors,
+  setDimensions,
+  colors,
+  dimensions,
+}) => {
   const [isShowModal, setIsShowModal] = useState(false);
 
   const handleAddBorderClick = useCallback(
@@ -216,10 +226,26 @@ const Border: FC<BorderProps> = ({ withDarkMode, borders, setBorders, colors, di
 
   const handleLoadNewBorders = useCallback(
     (props: SetStateAction<NonNullable<Type.KVStorage['borders']>>) => {
-      setIsShowModal(false);
       setBorders(props);
+      setIsShowModal(false);
     },
     [setBorders]
+  );
+
+  const handleLoadNewColors = useCallback(
+    (props: SetStateAction<NonNullable<Type.KVStorage['colors']>>) => {
+      setColors(props);
+      setIsShowModal(false);
+    },
+    [setColors]
+  );
+
+  const handleLoadNewDimensions = useCallback(
+    (props: SetStateAction<NonNullable<Type.KVStorage['dimensions']>>) => {
+      setDimensions(props);
+      setIsShowModal(false);
+    },
+    [setDimensions]
   );
 
   const renderBorders = useCallback(
@@ -267,7 +293,12 @@ const Border: FC<BorderProps> = ({ withDarkMode, borders, setBorders, colors, di
       </div>
       {isShowModal && (
         <ModalDialog onRequestClose={() => setIsShowModal(false)} className="custom-modal-wrapper">
-          <AddDesignTokensModal mode={TokenType.Border} setBorders={handleLoadNewBorders} />
+          <AddDesignTokensModal
+            mode={TokenType.Border}
+            setBorders={handleLoadNewBorders}
+            setColors={handleLoadNewColors}
+            setDimensions={handleLoadNewDimensions}
+          />
         </ModalDialog>
       )}
     </div>

--- a/src/components/Settings/Tabs/Color.tsx
+++ b/src/components/Settings/Tabs/Color.tsx
@@ -21,9 +21,20 @@ type ColorProps = {
   setColors: Dispatch<SetStateAction<NonNullable<Type.KVStorage['colors']>>>;
   setWithDarkMode: Dispatch<SetStateAction<NonNullable<Type.KVStorage['withDarkMode']>>>;
   setAllowGroups: Dispatch<SetStateAction<Type.KVStorage['allowedGroup']>>;
+  setDimensions: Dispatch<SetStateAction<NonNullable<Type.KVStorage['dimensions']>>>;
+  setBorders: Dispatch<SetStateAction<NonNullable<Type.KVStorage['borders']>>>;
 };
 
-const Color: FC<ColorProps> = ({ colors, allowGroups, withDarkMode, setColors, setWithDarkMode, setAllowGroups }) => {
+const Color: FC<ColorProps> = ({
+  colors,
+  allowGroups,
+  withDarkMode,
+  setColors,
+  setWithDarkMode,
+  setAllowGroups,
+  setDimensions,
+  setBorders,
+}) => {
   const [isShowAddDesignTokensModal, setIsShowAddDesignTokensModal] = useState(false);
   const [isShowGroupManagementModal, setIsShowGroupManagementModal] = useState(false);
 
@@ -51,10 +62,26 @@ const Color: FC<ColorProps> = ({ colors, allowGroups, withDarkMode, setColors, s
 
   const handleLoadNewColors = useCallback(
     (props: SetStateAction<NonNullable<Type.KVStorage['colors']>>) => {
-      setIsShowAddDesignTokensModal(false);
       setColors(props);
+      setIsShowAddDesignTokensModal(false);
     },
     [setColors]
+  );
+
+  const handleLoadNewDimensions = useCallback(
+    (props: SetStateAction<NonNullable<Type.KVStorage['dimensions']>>) => {
+      setDimensions(props);
+      setIsShowAddDesignTokensModal(false);
+    },
+    [setDimensions]
+  );
+
+  const handleLoadNewBorders = useCallback(
+    (props: SetStateAction<NonNullable<Type.KVStorage['borders']>>) => {
+      setBorders(props);
+      setIsShowAddDesignTokensModal(false);
+    },
+    [setBorders]
   );
 
   const handleDarkModeClick = useCallback(() => setWithDarkMode(prevState => !prevState), [setWithDarkMode]);
@@ -204,7 +231,13 @@ const Color: FC<ColorProps> = ({ colors, allowGroups, withDarkMode, setColors, s
           title="Upload design tokens"
           className="custom-modal-wrapper"
         >
-          <AddDesignTokensModal mode={TokenType.Color} setColors={handleLoadNewColors} isDarkEnable={withDarkMode} />
+          <AddDesignTokensModal
+            mode={TokenType.Color}
+            setColors={handleLoadNewColors}
+            isDarkEnable={withDarkMode}
+            setDimensions={handleLoadNewDimensions}
+            setBorders={handleLoadNewBorders}
+          />
         </ModalDialog>
       )}
       {isShowGroupManagementModal && (

--- a/src/components/Settings/Tabs/SizeDimension.tsx
+++ b/src/components/Settings/Tabs/SizeDimension.tsx
@@ -92,9 +92,18 @@ type SizeDimensionProps = {
   allowGroups?: string[];
   setDimensions: Dispatch<SetStateAction<NonNullable<Type.KVStorage['dimensions']>>>;
   setAllowGroups: Dispatch<SetStateAction<Type.KVStorage['allowedGroup']>>;
+  setColors: Dispatch<SetStateAction<NonNullable<Type.KVStorage['colors']>>>;
+  setBorders: Dispatch<SetStateAction<NonNullable<Type.KVStorage['borders']>>>;
 };
 
-export const SizeDimension: FC<SizeDimensionProps> = ({ dimensions, allowGroups, setDimensions, setAllowGroups }) => {
+export const SizeDimension: FC<SizeDimensionProps> = ({
+  dimensions,
+  allowGroups,
+  setDimensions,
+  setColors,
+  setBorders,
+  setAllowGroups,
+}) => {
   const [isShowAddDesignTokensModal, setIsShowAddDesignTokensModal] = useState(false);
   const [isShowGroupManagementModal, setIsShowGroupManagementModal] = useState(false);
 
@@ -122,10 +131,26 @@ export const SizeDimension: FC<SizeDimensionProps> = ({ dimensions, allowGroups,
 
   const handleLoadNewDimensions = useCallback(
     (props: SetStateAction<NonNullable<Type.KVStorage['dimensions']>>) => {
-      setIsShowAddDesignTokensModal(false);
       setDimensions(props);
+      setIsShowAddDesignTokensModal(false);
     },
     [setDimensions]
+  );
+
+  const handleLoadNewColors = useCallback(
+    (props: SetStateAction<NonNullable<Type.KVStorage['colors']>>) => {
+      setColors(props);
+      setIsShowAddDesignTokensModal(false);
+    },
+    [setColors]
+  );
+
+  const handleLoadNewBorders = useCallback(
+    (props: SetStateAction<NonNullable<Type.KVStorage['borders']>>) => {
+      setBorders(props);
+      setIsShowAddDesignTokensModal(false);
+    },
+    [setBorders]
   );
 
   const groupedDimensions = useMemo(
@@ -256,7 +281,12 @@ export const SizeDimension: FC<SizeDimensionProps> = ({ dimensions, allowGroups,
           title="Upload design tokens"
           className="custom-modal-wrapper"
         >
-          <AddDesignTokensModal mode={TokenType.Dimension} setDimensions={handleLoadNewDimensions} />
+          <AddDesignTokensModal
+            mode={TokenType.Dimension}
+            setDimensions={handleLoadNewDimensions}
+            setColors={handleLoadNewColors}
+            setBorders={handleLoadNewBorders}
+          />
         </ModalDialog>
       )}
       {isShowGroupManagementModal && (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,6 +54,7 @@ export enum TokenType {
   Dimension = 'dimension',
   Font = 'font',
   Border = 'border',
+  All = 'all',
 }
 
 export enum CONTROL_VARIANT {

--- a/src/pages/api/setAllowedGroups.ts
+++ b/src/pages/api/setAllowedGroups.ts
@@ -14,7 +14,7 @@ const setAllowedGroups = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!environmentUrl) return res.status(401).json({ message: 'We are not able to recognize the environment' });
 
     const response = await checkRoles(projectId, xApiKey, environmentUrl);
-    if (!response.ok) return res.status(response.status).json({ message: 'API key was not valid' });
+    if (!response.ok) return res.status(response.status).json({ message: response.message });
 
     const projectKey = typeof projectId === 'string' ? projectId : projectId[0];
 

--- a/src/pages/api/setBorders.ts
+++ b/src/pages/api/setBorders.ts
@@ -12,7 +12,7 @@ const setBorder = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!environmentUrl) return res.status(401).json({ message: 'We are not able to recognize the environment' });
 
     const response = await checkRoles(projectId, xApiKey, environmentUrl);
-    if (!response.ok) return res.status(response.status).json({ message: 'API key was not valid' });
+    if (!response.ok) return res.status(response.status).json({ message: response.message });
 
     const projectKey = typeof projectId === 'string' ? projectId : projectId[0];
 

--- a/src/pages/api/setColors.ts
+++ b/src/pages/api/setColors.ts
@@ -15,7 +15,7 @@ const setColors = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!environmentUrl) return res.status(401).json({ message: 'We are not able to recognize the environment' });
 
     const response = await checkRoles(projectId, xApiKey, environmentUrl);
-    if (!response.ok) return res.status(response.status).json({ message: 'API key was not valid' });
+    if (!response.ok) return res.status(response.status).json({ message: response.message });
 
     const projectKey = typeof projectId === 'string' ? projectId : projectId[0];
 

--- a/src/pages/api/setDefaultFont.ts
+++ b/src/pages/api/setDefaultFont.ts
@@ -12,7 +12,7 @@ const setDefaultFont = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!environmentUrl) return res.status(401).json({ message: 'We are not able to recognize the environment' });
 
     const response = await checkRoles(projectId, xApiKey, environmentUrl);
-    if (!response.ok) return res.status(response.status).json({ message: 'API key was not valid' });
+    if (!response.ok) return res.status(response.status).json({ message: response.message });
 
     const projectKey = typeof projectId === 'string' ? projectId : projectId[0];
 

--- a/src/pages/api/setDimensions.ts
+++ b/src/pages/api/setDimensions.ts
@@ -12,7 +12,7 @@ const setDimensions = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!environmentUrl) return res.status(401).json({ message: 'We are not able to recognize the environment' });
 
     const response = await checkRoles(projectId, xApiKey, environmentUrl);
-    if (!response.ok) return res.status(response.status).json({ message: 'API key was not valid' });
+    if (!response.ok) return res.status(response.status).json({ message: response.message });
 
     const projectKey = typeof projectId === 'string' ? projectId : projectId[0];
     const data = req.body as Record<string, string>;

--- a/src/pages/api/setFonts.ts
+++ b/src/pages/api/setFonts.ts
@@ -12,8 +12,7 @@ const setFonts = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!environmentUrl) return res.status(401).json({ message: 'We are not able to recognize the environment' });
 
     const response = await checkRoles(projectId, xApiKey, environmentUrl);
-
-    if (!response.ok) return res.status(response.status).json({ message: 'API key was not valid' });
+    if (!response.ok) return res.status(response.status).json({ message: response.message });
 
     const projectKey = typeof projectId === 'string' ? projectId : projectId[0];
 

--- a/src/types/Type.d.ts
+++ b/src/types/Type.d.ts
@@ -17,7 +17,7 @@ declare namespace Type {
 
   type KVMetaData = { metaData?: { environment: string; lastUpdated: string } };
 
-  type DesignToken = { key: string; value: string | object };
+  type DesignToken = { key: string; value: string | object; type: TokenType };
 
   type Callout = {
     type: 'caution' | 'danger' | 'info' | 'note' | 'success' | 'tip' | 'error';


### PR DESCRIPTION
Adds functionality to load all design token types (color, dimension, border) simultaneously from a single file or URL.

Simplifies the process of importing design tokens and reduces the number of steps required to configure a project.

Also, fixes an issue where changes to design tokens were not being reflected in the UI.